### PR TITLE
Game Cube logo with white letters

### DIFF
--- a/gc/art/system2.svg
+++ b/gc/art/system2.svg
@@ -1,0 +1,537 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="160.00024mm"
+   height="35.060467mm"
+   viewBox="0 0 566.93 124.23"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="gamecube white.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.24748737"
+     inkscape:cx="2014.3452"
+     inkscape:cy="534.52157"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1137"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Livello 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-76.535,-98.818634)">
+    <g
+       id="underneath_1_"
+       transform="translate(76.535,98.818634)" />
+    <g
+       id="BOTTOM_LEFT_LINE"
+       transform="translate(76.535,98.818634)" />
+    <g
+       id="g4606">
+      <g
+         transform="translate(76.535,98.818634)"
+         id="g4141">
+        <g
+           id="Layer_6">
+          <line
+             style="fill:none"
+             x1="29.247999"
+             y1="99.123001"
+             x2="28.120001"
+             y2="98.281998"
+             id="line4144" />
+        </g>
+        <g
+           id="_x33_D_PART">
+          <linearGradient
+             id="SVGID_1_"
+             gradientUnits="userSpaceOnUse"
+             x1="24.4146"
+             y1="564.87183"
+             x2="104.7434"
+             y2="551.50897"
+             gradientTransform="translate(-0.0049,-473.4258)">
+            <stop
+               offset="0.0368"
+               style="stop-color:#FFFFFF"
+               id="stop4148" />
+            <stop
+               offset="0.8957"
+               style="stop-color:#898CBF"
+               id="stop4150" />
+          </linearGradient>
+          <polygon
+             style="fill:url(#SVGID_1_)"
+             points="53.699,103.224 18.222,82.608 16.628,83.691 53.699,105.427 91.065,83.824 91.065,61.505 89.451,62.438 89.451,82.608 "
+             id="polygon4152" />
+        </g>
+        <g
+           id="black_line_thing">
+          <polygon
+             style="fill:#7a7eae"
+             points="89.308,82.69 89.451,82.608 89.451,82.52 91.065,83.685 91.065,83.824 90.963,83.9 "
+             id="polygon4155" />
+        </g>
+        <g
+           id="dark_purple_top_line">
+          <linearGradient
+             id="SVGID_2_"
+             gradientUnits="userSpaceOnUse"
+             x1="28.460899"
+             y1="68.8367"
+             x2="54.048801"
+             y2="68.8367"
+             gradientTransform="matrix(1,0,0,-1,-0.0449,123.9897)">
+            <stop
+               offset="0"
+               style="stop-color:#6E70A9"
+               id="stop4159" />
+            <stop
+               offset="0.9693"
+               style="stop-color:#514A8E"
+               id="stop4161" />
+          </linearGradient>
+          <polygon
+             style="fill:url(#SVGID_2_)"
+             points="28.416,47.853 53.699,62.851 54.004,62.205 28.814,47.455 "
+             id="polygon4163" />
+          <linearGradient
+             id="SVGID_3_"
+             gradientUnits="userSpaceOnUse"
+             x1="53.857399"
+             y1="61.680901"
+             x2="54.185001"
+             y2="61.680901"
+             gradientTransform="matrix(1,0,0,-1,-0.0449,123.9897)">
+            <stop
+               offset="0"
+               style="stop-color:#6E70A9"
+               id="stop4166" />
+            <stop
+               offset="0.9693"
+               style="stop-color:#514A8E"
+               id="stop4168" />
+          </linearGradient>
+          <polygon
+             style="fill:url(#SVGID_3_)"
+             points="54.14,62.413 53.813,62.413 53.922,62.205 54.107,62.205 "
+             id="polygon4170" />
+        </g>
+        <g
+           id="top_black_line">
+          <polygon
+             style="fill:#120f22"
+             points="107.627,31.206 107.785,31.647 54.004,62.851 54.004,62.205 "
+             id="polygon4173" />
+        </g>
+        <g
+           id="LOGO_DARK_LINES">
+          <polygon
+             style="fill:#453d76"
+             points="91.582,84.28 91.72,61.312 91.065,61.312 91.065,83.824 53.699,105.427 53.565,124.23 54.004,124.23 54.363,105.729 "
+             id="polygon4176" />
+        </g>
+        <g
+           id="LOGO">
+          <linearGradient
+             id="SVGID_4_"
+             gradientUnits="userSpaceOnUse"
+             x1="64.084503"
+             y1="540.32593"
+             x2="108.7263"
+             y2="569.63147"
+             gradientTransform="translate(-0.0049,-473.4258)">
+            <stop
+               offset="0"
+               style="stop-color:#4C5284"
+               id="stop4180" />
+            <stop
+               offset="1"
+               style="stop-color:#8789BC"
+               id="stop4182" />
+          </linearGradient>
+          <polygon
+             style="fill:url(#SVGID_4_)"
+             points="54.004,91.212 54.004,62.851 107.785,31.647 107.785,93.197 54.004,124.23 54.004,105.573 91.361,84.062 91.361,61.332 78.85,68.566 78.85,76.595 "
+             id="polygon4184" />
+        </g>
+        <g
+           id="BOTTOM_LAIN_LEFT_LIGHT_LINE">
+          <linearGradient
+             id="SVGID_5_"
+             gradientUnits="userSpaceOnUse"
+             x1="53.463902"
+             y1="596.99878"
+             x2="53.152901"
+             y2="577.09552"
+             gradientTransform="translate(-0.0049,-473.4258)">
+            <stop
+               offset="0.1104"
+               style="stop-color:#4C407E"
+               id="stop4188" />
+            <stop
+               offset="0.8896"
+               style="stop-color:#666699"
+               id="stop4190" />
+            <stop
+               offset="1"
+               style="stop-color:#A7B3D9"
+               id="stop4192" />
+            <stop
+               offset="1"
+               style="stop-color:#9BA5CD"
+               id="stop4194" />
+          </linearGradient>
+          <polyline
+             style="fill:url(#SVGID_5_)"
+             points="53.402,124.23 53.699,124.23 53.699,105.427 52.642,104.806 53.402,124.23    "
+             id="polyline4196" />
+        </g>
+        <g
+           id="underneath">
+          <polyline
+             style="fill:#2d2868"
+             points="16.542,40.703 16.771,40.897 16.862,83.532 16.628,83.691 16.486,83.601 16.542,40.703    "
+             id="polyline4199" />
+        </g>
+        <g
+           id="LEFT_3D_PURPLE_SHADOW">
+          <polygon
+             style="fill:#453d76"
+             points="54.004,21.3 18.26,41.987 18.222,82.608 16.628,83.691 16.628,40.755 54.004,19.174 "
+             id="polygon4202" />
+        </g>
+        <g
+           id="MAIN_DARK_PURPLE_LINE">
+          <polygon
+             style="fill:#453d76"
+             points="54.004,62.094 54.004,91.212 53.699,91.417 53.699,62.851 53.699,62.028 "
+             id="polygon4205" />
+        </g>
+        <g
+           id="logo_LEFT_side">
+          <linearGradient
+             id="SVGID_6_"
+             gradientUnits="userSpaceOnUse"
+             x1="4.8237"
+             y1="553.13263"
+             x2="66.025902"
+             y2="536.12347"
+             gradientTransform="translate(-0.0049,-473.4258)">
+            <stop
+               offset="0.2331"
+               style="stop-color:#666699"
+               id="stop4209" />
+            <stop
+               offset="0.7239"
+               style="stop-color:#A7B3D9"
+               id="stop4211" />
+          </linearGradient>
+          <polygon
+             style="fill:url(#SVGID_6_)"
+             points="53.699,91.417 53.699,62.851 28.416,47.853 28.416,76.802 "
+             id="polygon4213" />
+          <linearGradient
+             id="SVGID_7_"
+             gradientUnits="userSpaceOnUse"
+             x1="5.8822999"
+             y1="556.9314"
+             x2="67.0802"
+             y2="539.92352"
+             gradientTransform="translate(-0.0049,-473.4258)">
+            <stop
+               offset="0.2331"
+               style="stop-color:#666699"
+               id="stop4216" />
+            <stop
+               offset="0.9907"
+               style="stop-color:#A7B3D9"
+               id="stop4218" />
+          </linearGradient>
+          <polygon
+             style="fill:url(#SVGID_7_)"
+             points="16.628,40.964 0,31.206 0,93.302 53.402,124.23 53.402,123.926 53.402,105.251 16.628,83.691 "
+             id="polygon4220" />
+        </g>
+        <g
+           id="left_purple_line">
+          <rect
+             style="fill:#2d2868"
+             x="16.343"
+             y="40.755001"
+             width="0.285"
+             height="42.938"
+             id="rect4223" />
+          <polygon
+             style="fill:#2d2868"
+             points="0,31.206 16.486,40.897 16.628,40.755 0.214,30.992 "
+             id="polygon4225" />
+        </g>
+        <g
+           id="BOTTOM_PURPLE_LINE">
+          <linearGradient
+             id="SVGID_8_"
+             gradientUnits="userSpaceOnUse"
+             x1="19.585899"
+             y1="559.81421"
+             x2="43.920799"
+             y2="572.83582"
+             gradientTransform="translate(-0.0049,-473.4258)">
+            <stop
+               offset="0"
+               style="stop-color:#6E70A9"
+               id="stop4229" />
+            <stop
+               offset="0.9693"
+               style="stop-color:#514A8E"
+               id="stop4231" />
+          </linearGradient>
+          <polygon
+             style="fill:url(#SVGID_8_)"
+             points="53.402,105.251 53.402,105.603 16.343,84.015 16.343,83.691 16.628,83.691 "
+             id="polygon4233" />
+        </g>
+        <g
+           id="top_middle_light_line">
+          <linearGradient
+             id="SVGID_9_"
+             gradientUnits="userSpaceOnUse"
+             x1="55.734901"
+             y1="495.65411"
+             x2="71.185303"
+             y2="503.17059"
+             gradientTransform="translate(-0.0049,-473.4258)">
+            <stop
+               offset="0.0368"
+               style="stop-color:#9EA5D3"
+               id="stop4237" />
+            <stop
+               offset="0.9018"
+               style="stop-color:#7675AE"
+               id="stop4239" />
+          </linearGradient>
+          <polygon
+             style="fill:url(#SVGID_9_)"
+             points="77.901,35.231 54.004,21.3 54.004,19.174 77.901,33.142 "
+             id="polygon4241" />
+        </g>
+        <g
+           id="top_right">
+          <polygon
+             style="fill:#484592"
+             points="94.454,25.524 94.454,23.552 77.901,33.142 77.901,35.231 "
+             id="polygon4244" />
+        </g>
+        <g
+           id="MAIN_TOP">
+          <path
+             style="fill:none"
+             inkscape:connector-curvature="0"
+             d="M 0,31.206"
+             id="path4247" />
+          <linearGradient
+             id="SVGID_10_"
+             gradientUnits="userSpaceOnUse"
+             x1="0.21879999"
+             y1="504.41769"
+             x2="0.21879999"
+             y2="504.41769"
+             gradientTransform="translate(-0.0049,-473.4258)">
+            <stop
+               offset="0.2331"
+               style="stop-color:#666699"
+               id="stop4250" />
+            <stop
+               offset="0.9907"
+               style="stop-color:#A7B3D9"
+               id="stop4252" />
+          </linearGradient>
+          <path
+             style="fill:url(#SVGID_10_)"
+             inkscape:connector-curvature="0"
+             d="M 0.214,30.992"
+             id="path4254" />
+          <linearGradient
+             id="SVGID_11_"
+             gradientUnits="userSpaceOnUse"
+             x1="49.3857"
+             y1="477.94699"
+             x2="45.741199"
+             y2="518.44202"
+             gradientTransform="translate(-0.0049,-473.4258)">
+            <stop
+               offset="0"
+               style="stop-color:#AAACD2"
+               id="stop4257" />
+            <stop
+               offset="0.6258"
+               style="stop-color:#FCFAFB"
+               id="stop4259" />
+          </linearGradient>
+          <polygon
+             style="fill:url(#SVGID_11_)"
+             points="16.628,40.755 0.214,30.992 53.833,0 94.454,23.552 77.901,33.142 54.004,19.174 "
+             id="polygon4261" />
+          <linearGradient
+             id="SVGID_12_"
+             gradientUnits="userSpaceOnUse"
+             x1="71.7798"
+             y1="473.26541"
+             x2="68.135201"
+             y2="513.76123"
+             gradientTransform="translate(-0.0049,-473.4258)">
+            <stop
+               offset="0.6743"
+               style="stop-color:#AAACD2"
+               id="stop4264" />
+            <stop
+               offset="1"
+               style="stop-color:#FCFAFB"
+               id="stop4266" />
+          </linearGradient>
+          <polygon
+             style="fill:url(#SVGID_12_)"
+             points="107.627,31.206 54.004,62.205 28.814,47.455 53.68,33.409 77.369,46.781 106.232,30.192 "
+             id="polygon4268" />
+        </g>
+      </g>
+      <g
+         style="fill:#ffffff"
+         transform="translate(76.535,98.818634)"
+         id="g4270">
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23497"
+           d="m 373.52,21.158 0,-4.949 -14.143,0 c -1.816,0 -3.533,0.404 -5.054,1.11 -1.513,0.71 -2.726,1.718 -3.634,2.932 -0.908,1.209 -1.314,2.529 -1.416,4.04 l 0,15.252 c 0.1,1.417 0.508,2.729 1.313,3.944 0.912,1.21 2.121,2.116 3.537,2.924 1.516,0.71 3.127,1.115 5.053,1.115 l 14.34,0 0,-4.949 -13.739,0 c -1.11,0 -2.118,-0.306 -3.022,-0.911 -0.815,-0.604 -1.318,-1.312 -1.318,-2.319 l 0,-5.657 18.082,0 0,-5.053 -18.082,0 0,-4.142 c 0,-1.013 0.503,-1.817 1.318,-2.427 0.904,-0.606 1.912,-0.91 3.022,-0.91 l 13.739,0" />
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23501"
+           d="m 457.952,16.21 0,31.317 15.102,0 c 1.916,-0.098 3.625,-0.405 5.139,-1.107 1.609,-0.804 2.818,-1.712 3.723,-2.921 0.908,-1.203 1.307,-2.615 1.408,-4.127 l 0,-15.106 c -0.102,-1.507 -0.5,-2.821 -1.408,-4.028 -0.904,-1.208 -2.111,-2.213 -3.723,-2.921 -1.514,-0.705 -3.225,-1.107 -5.139,-1.107 l -15.102,0 0,0 z m 17.826,5.842 c 0.898,0.604 1.303,1.407 1.404,2.418 l 0,14.803 c -0.104,1.006 -0.506,1.812 -1.404,2.416 -0.809,0.703 -1.82,1.005 -2.928,1.005 l -8.758,0 0,-21.648 8.758,0 c 1.108,0 2.119,0.301 2.928,1.006" />
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23503"
+           d="m 531.958,17.302 c -1.488,-0.692 -3.172,-0.993 -5.053,-1.093 l -5.453,0 c -1.885,0.099 -3.566,0.4 -5.057,1.093 -1.584,0.794 -2.775,1.68 -3.666,2.874 -0.895,1.186 -1.389,2.576 -1.389,4.063 l 0,15.359 c 0,1.486 0.494,2.777 1.389,3.967 0.891,1.19 2.082,2.179 3.666,2.874 1.49,0.693 3.172,1.089 5.057,1.089 l 5.453,0 c 1.881,0 3.563,-0.396 5.053,-1.089 1.584,-0.694 2.773,-1.684 3.666,-2.874 0.893,-1.191 1.387,-2.577 1.387,-3.967 l 0,-15.36 c -0.096,-1.487 -0.494,-2.877 -1.387,-4.063 -0.893,-1.194 -2.082,-2.08 -3.666,-2.873 z m -2.379,4.656 c 0.891,0.694 1.387,1.484 1.387,2.382 l 0,15.059 c 0,0.892 -0.496,1.686 -1.387,2.379 -0.793,0.597 -1.787,0.994 -2.873,0.994 l -5.055,0 c -1.094,0 -2.084,-0.396 -2.977,-0.994 -0.789,-0.694 -1.285,-1.487 -1.285,-2.379 l 0,-15.059 c 0,-0.897 0.496,-1.688 1.285,-2.382 0.893,-0.596 1.883,-0.893 2.977,-0.992 l 5.055,0 c 1.087,0.101 2.08,0.397 2.873,0.992" />
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23515"
+           d="m 169.301,16.21 -6.163,0 0,20.003 -10.504,-20.003 -8.385,0 0,31.317 6.163,0 0,-24.444 12.828,24.444 6.061,0 0,-31.317" />
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23515_1_"
+           d="m 269.711,16.21 -6.163,0 0,20.003 -10.505,-20.003 -8.385,0 0,31.317 6.163,0 0,-24.444 12.828,24.444 6.062,0 0,-31.317" />
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23515_2_"
+           d="m 428.299,16.21 -6.162,0 0,20.003 -10.504,-20.003 -8.387,0 0,31.317 6.163,0 0,-24.444 12.828,24.444 6.062,0 0,-31.317" />
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23517"
+           d="m 210.526,47.527 0,-31.317 -7.07,0 0,31.317 7.07,0 0,0" />
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23521"
+           d="m 296.922,16.21 0,4.949 10.401,0 0,26.369 6.671,0 0,-26.37 10.504,0 0,-4.949 -27.578,0 0,0" />
+      </g>
+      <g
+         style="fill:#ffffff"
+         transform="translate(76.535,98.818634)"
+         id="g4280">
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23505"
+           d="m 543.92,69.03 0,-8.463 -42.717,0 0,40.229 43.113,0 0,-9.062 -31.855,0 0,-7.57 18.316,0 0,-8.457 -18.316,0 0,-6.677 31.459,0 0,0" />
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23507"
+           d="m 496.374,68.755 c 0.096,-2.785 -0.697,-4.977 -2.393,-6.274 -1.596,-1.394 -4.08,-2.09 -7.467,-2.09 l -35.148,0 0,40.325 32.658,0 c 8.563,-0.099 12.744,-2.887 12.744,-8.562 l 0,-4.883 c 0,-3.382 -1.492,-5.87 -4.582,-7.262 2.789,-1.298 4.188,-3.487 4.188,-6.576 l 0,-4.678 0,0 z m -10.854,0.2 c 0.398,0.399 0.602,0.8 0.496,1.396 l 0,3.685 c 0.104,0.495 -0.098,0.995 -0.496,1.293 l -2.795,0.495 -20.107,0 0,-7.266 20.107,0 c 1.502,0 2.496,0.199 2.795,0.397 l 0,0 z m -22.902,22.9 0,-7.867 20.211,0 c 1.496,0 2.393,0.201 2.889,0.5 0.402,0.401 0.596,0.998 0.596,1.993 l 0,2.886 c 0,0.897 -0.191,1.594 -0.596,1.891 -0.496,0.4 -1.393,0.597 -2.889,0.597 l -20.211,0" />
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23509"
+           d="m 446.614,60.458 -11.25,0 0,31.167 -24.396,0 0,-31.167 -11.248,0 0,30.271 c -0.106,2.486 0.295,4.484 0.99,5.975 0.6,1.395 1.797,2.49 3.389,3.089 1.597,0.695 3.684,0.993 6.47,0.896 l 25.093,0 c 2.789,0.097 4.977,-0.201 6.57,-0.896 1.59,-0.599 2.689,-1.694 3.389,-3.089 0.695,-1.491 0.996,-3.487 0.996,-5.975 l 0,-30.271" />
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23511"
+           d="m 394.09,64.607 c -0.705,-1.489 -1.896,-2.488 -3.388,-3.186 -1.596,-0.602 -3.784,-0.898 -6.473,-0.898 l -24.591,0 c -2.789,0 -4.881,0.298 -6.478,0.898 -1.591,0.697 -2.786,1.696 -3.382,3.186 -0.697,1.494 -1.096,3.484 -0.993,5.974 l 0,20.214 c -0.103,2.484 0.296,4.48 0.993,5.971 0.596,1.396 1.791,2.491 3.382,3.093 1.597,0.693 3.688,0.991 6.478,0.893 l 24.592,0 c 2.688,0.098 4.877,-0.199 6.473,-0.893 1.492,-0.602 2.684,-1.697 3.387,-3.093 0.597,-1.489 0.996,-3.485 0.996,-5.971 l 0,-7.371 -11.256,0.105 0,8.162 -23.893,0 0,-22.301 23.893,0 0,7.165 11.256,0 0,-5.974 c 0,-2.585 -0.399,-4.574 -0.996,-5.974" />
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23513"
+           d="m 340.461,69.03 0,-8.463 -42.718,0 0,40.229 43.116,0 0,-9.062 -31.861,0 0,-7.57 18.321,0 0,-8.457 -18.321,0 0,-6.677 31.463,0 0,0" />
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23523"
+           d="m 282.411,60.458 -17.127,28.48 -17.025,-28.48 -10.254,0 0,33.159 -20.016,-33.159 -10.056,0 -23.994,40.228 30.068,0 0,-9.061 -13.442,0 12.447,-20.013 16.828,29.072 18.519,0 0,-21.505 12.842,21.505 8.266,0 12.942,-21.505 0,21.505 10.354,0 0,-40.227 -10.354,0 0,0" />
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23525"
+           d="m 184.83,69.307 0,-8.77 -37.938,0 c -2.685,0 -4.879,0.3 -6.474,0.899 -1.59,0.696 -2.686,1.698 -3.381,3.187 -0.7,1.493 -0.998,3.483 -0.998,5.975 l 0,20.21 c 0,2.486 0.298,4.483 0.998,5.975 0.696,1.395 1.792,2.49 3.381,3.091 1.594,0.692 3.789,0.991 6.474,0.895 l 27.584,0 c 3.978,0.097 6.768,-0.599 8.458,-2.091 1.595,-1.595 2.391,-4.183 2.294,-7.868 l 0,-14.24 -26.088,0 0,8.47 15.135,0 0,6.667 -26.985,0 0,-22.4 37.54,0" />
+      </g>
+      <g
+         style="fill:#ffffff"
+         transform="translate(76.535,98.818634)"
+         id="g4289">
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23527"
+           d="m 566.93,91.979 -1.693,0 -2.041,6.45 c -0.334,0.513 -0.51,1.024 -0.51,1.362 -0.172,-0.338 -0.346,-0.682 -0.512,-1.188 l -2.211,-6.626 -1.699,0 0,9.17 1.027,0 0,-7.813 2.717,7.813 1.012,0 2.721,-7.642 0,7.642 1.189,0 0,-9.168" />
+        <path
+           style="fill:#ffffff"
+           inkscape:connector-curvature="0"
+           id="path23529"
+           d="m 554.016,93.167 2.893,0 0,-1.188 -7.139,0 0,1.188 3.063,0 0,7.982 1.186,0 0,-7.982" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
The black letters becomes invisible on Carbon theme.

We noticed it when playing with a way to automatically generate runcommand launching images for the Carbon theme using ImageMagick tools.

https://retropie.org.uk/forum/post/46352